### PR TITLE
Added support for different probe types (now entered by name in config) as well as humidity sensor support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TH16ermostat 
 ## Homebridge plugin for Sonoff TH16/TH10
 
-This is a simple accessory plugin to control Sonoff TH16/TH10 with thermal probe (DS18B20) like a thermostat.
-Version 0.0.2 so use on you own risk and be patient. Planning to support at least one probe with humidity sensor (Sonoff AM2301) once it arrives from China.
+This is a simple accessory plugin to control Sonoff TH16/TH10 with thermal probe (DS18B20, SI7021, others) like a thermostat.
+Use on you own risk and be patient. Planning to support at least one probe with humidity sensor (Sonoff AM2301) once it arrives from China.
 
 # Prerequisities
 
@@ -25,6 +25,7 @@ _Note: If if fails to start/initialize after installing and configuring through 
         {
             "accessory": "TH16ermostat",
             "name": "Kitchen Infra Heater",
+            "sensorName": "DS18B20",
             "deviceIPAddress": "",
 
             "minTemp": -25,
@@ -44,6 +45,7 @@ _Note: If if fails to start/initialize after installing and configuring through 
 # Description of settings
 
 ```
+    "sensorName"        "TH16 (Tasmota) connected sensor name (check http://x.x.x.x/cm?cmnd=status%208)"
     "minTemp"           "Minimum Temperature allowed to set (shown in UI)",
     "maxTemp"           "Maximum Temperature allowed to set (shown in UI)",
     "stepTemp"          "Step to increment/decrement the temperature in UI.",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ## Homebridge plugin for Sonoff TH16/TH10
 
 This is a simple accessory plugin to control Sonoff TH16/TH10 with thermal probe (DS18B20, SI7021, others) like a thermostat.
-Use on you own risk and be patient. Planning to support at least one probe with humidity sensor (Sonoff AM2301) once it arrives from China.
+Humidity sensors are supported and can be enabled or disabled.
+Use on you own risk and be patient.
 
 # Prerequisities
 
@@ -26,6 +27,7 @@ _Note: If if fails to start/initialize after installing and configuring through 
             "accessory": "TH16ermostat",
             "name": "Kitchen Infra Heater",
             "sensorName": "DS18B20",
+            "enableHumidity": "boolean",
             "deviceIPAddress": "",
 
             "minTemp": -25,
@@ -45,7 +47,8 @@ _Note: If if fails to start/initialize after installing and configuring through 
 # Description of settings
 
 ```
-    "sensorName"        "TH16 (Tasmota) connected sensor name (check http://x.x.x.x/cm?cmnd=status%208)"
+    "sensorName"        "TH16 (Tasmota) connected sensor name (check http://x.x.x.x/cm?cmnd=status%208)",
+    "enableHumidity"    "You should disable this if thermal probe does not include humidity sensor.",
     "minTemp"           "Minimum Temperature allowed to set (shown in UI)",
     "maxTemp"           "Maximum Temperature allowed to set (shown in UI)",
     "stepTemp"          "Step to increment/decrement the temperature in UI.",

--- a/config.schema.json
+++ b/config.schema.json
@@ -10,6 +10,12 @@
             "required": true,
             "placeholder": "Kitchen Infra Heater"
         },
+        "sensorName": {
+            "title": "Temperature sensor name/type",
+            "type": "string",
+            "required": true,
+            "placeholder": "DS18B20"
+        },
         "minTemp": {
             "title": "Minimum Temperature",
             "type": "number",

--- a/config.schema.json
+++ b/config.schema.json
@@ -16,6 +16,11 @@
             "required": true,
             "placeholder": "DS18B20"
         },
+        "enableHumidity": {
+            "title": "Enable humidity sensor if available on the sensor.",
+            "type": "boolean",
+            "default": true
+        },
         "minTemp": {
             "title": "Minimum Temperature",
             "type": "number",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ class TH16ermostatPlugin implements AccessoryPlugin {
     // Config values
     this.sensorName = config.sensorName as string;
     this.deviceIPAddress = config.deviceIPAddress as string;
-    this.enableHumidity = config.separateHumidity as boolean;
+    this.enableHumidity = config.enableHumidity as boolean;
     this.deviceStatStatus = config.deviceStatStatus as string || this.deviceStatStatus;
     this.deviceStatPower = config.deviceStatPower as string || this.deviceStatPower;
     this.deviceCmndOn = config.deviceCmndOn as string || this.deviceCmndOn;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ class TH16ermostatPlugin implements AccessoryPlugin {
 
   // config
   private readonly name: string;
+  private readonly sensorName: string;
   private readonly minTemp: number = -25;
   private readonly maxTemp: number = 25;
   private readonly deltaTemp: number = 0.2;
@@ -62,6 +63,7 @@ class TH16ermostatPlugin implements AccessoryPlugin {
     this.name = config.name;
 
     // Config values
+    this.sensorName = config.sensorName as string;
     this.deviceIPAddress = config.deviceIPAddress as string;
     this.deviceStatStatus = config.deviceStatStatus as string || this.deviceStatStatus;
     this.deviceStatPower = config.deviceStatPower as string || this.deviceStatPower;
@@ -208,7 +210,7 @@ class TH16ermostatPlugin implements AccessoryPlugin {
 
         await axios.get(url + this.deviceStatStatus, { timeout: 3000 })
           .then((response) => {
-            tmp = parseFloat(response.data.StatusSNS.DS18B20.Temperature);
+            tmp = parseFloat(response.data.StatusSNS[this.sensorName].Temperature);
           }).catch((err) => {
             throw new Error('Failed to get status: cmd=' + this.deviceStatStatus + ' [' + err + ']');
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ class TH16ermostatPlugin implements AccessoryPlugin {
   // state
   private currTemp = '';
   private targetTemp = 0;
+  private currRelativeHumidity = '';
   private currentHeatingState = hap.Characteristic.CurrentHeatingCoolingState.OFF; // [0, 1] only
   private targetHeatingState = hap.Characteristic.TargetHeatingCoolingState.OFF; // [0, 1, 3] only
   private pollingTimer;
@@ -163,6 +164,12 @@ class TH16ermostatPlugin implements AccessoryPlugin {
         callback();
       });
 
+    this.thermostatService.getCharacteristic(hap.Characteristic.CurrentRelativeHumidity)
+      .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        this.log.info('Get CURRENT relative humidity: ' + this.currRelativeHumidity);
+        callback(undefined, this.currRelativeHumidity);
+      });
+
     // init Information service
     this.informationService
       .setCharacteristic(hap.Characteristic.Manufacturer, 'Sonoff')
@@ -205,12 +212,19 @@ class TH16ermostatPlugin implements AccessoryPlugin {
 
     const deviceStatus =
       async () => {
-        let pwr, tmp;
+        let pwr, tmp, hum;
         const url = 'http://' + this.deviceIPAddress;
 
         await axios.get(url + this.deviceStatStatus, { timeout: 3000 })
           .then((response) => {
             tmp = parseFloat(response.data.StatusSNS[this.sensorName].Temperature);
+          }).catch((err) => {
+            throw new Error('Failed to get status: cmd=' + this.deviceStatStatus + ' [' + err + ']');
+          });
+
+        await axios.get(url + this.deviceStatStatus, { timeout: 3000 })
+          .then((response) => {
+            hum = parseFloat(response.data.StatusSNS[this.sensorName].Humidity);
           }).catch((err) => {
             throw new Error('Failed to get status: cmd=' + this.deviceStatStatus + ' [' + err + ']');
           });
@@ -224,7 +238,7 @@ class TH16ermostatPlugin implements AccessoryPlugin {
             throw new Error('Failed to get power status: cmd=' + this.deviceStatPower + ' [' + err + ']');
           });
 
-        return { 'TMP_STAT': (await tmp), 'PWR_STAT': (await pwr) };
+        return { 'TMP_STAT': (await tmp), 'HUM_STAT': (await hum), 'PWR_STAT': (await pwr) };
       };
 
     deviceStatus()
@@ -235,6 +249,7 @@ class TH16ermostatPlugin implements AccessoryPlugin {
 
         // state values
         this.currTemp = response['TMP_STAT'] as string;
+        this.currRelativeHumidity = response['HUM_STAT'] as string;
         this.currentHeatingState = response['PWR_STAT'] as number;
         this.thermostatService.setCharacteristic(hap.Characteristic.CurrentTemperature, this.currTemp);
 
@@ -273,6 +288,8 @@ class TH16ermostatPlugin implements AccessoryPlugin {
       .catch((err) => {
         this.currTemp = '--';
         this.thermostatService.setCharacteristic(hap.Characteristic.CurrentTemperature, this.currTemp);
+        this.currRelativeHumidity = "--";
+        this.thermostatService.setCharacteristic(hap.Characteristic.CurrentRelativeHumidity, this.currRelativeHumidity);
 
         // output error only once, do not spam the log on each poll
         if (!this.isOffline) {


### PR DESCRIPTION
I have added support for any/all probes by letting the user fill in their sensor name when adding the accessory.
This replaces the hardcoded DS18B20 reference that you coded for when pulling the status from Tasmota.

I have also added support for humidity sensors.
The user can enable/disable this from the plugin settings page per accessory.
If the probe does not support humidity sensing, it will just show "--%".
Ideally, this is something that the plugin can detect when calling the Tasmota status page...
Could be a feature in the future but not for now :)

I'm pretty new to Github so feel free to share your unfiltered feedback with me.